### PR TITLE
Fix the content flash problems with contexts

### DIFF
--- a/src/lib/Navbar.svelte
+++ b/src/lib/Navbar.svelte
@@ -1,9 +1,9 @@
 <script>
-  import { user } from "./store";
+  export let user;
 </script>
 
 <header>
-  {#if $user}Logged in as {$user}!{:else}Not logged in{/if}
+  {#if user}Logged in as {user}!{:else}Not logged in{/if}
 </header>
 
 <hr />

--- a/src/routes/__layout.svelte
+++ b/src/routes/__layout.svelte
@@ -6,18 +6,14 @@
   export async function load({ fetch, session }) {
     if (!session.jwt) {
       return {
-        props: {
-          fetchedUser: false
-        }
+        props: { fetchedUser: false },
       };
     }
 
     const storedUser = get(user);
     if (browser && storedUser) {
       return {
-        props: {
-          fetchedUser: storedUser
-        }
+        props: { fetchedUser: storedUser },
       };
     }
 
@@ -25,12 +21,8 @@
     const fetchedUser = await res.text();
 
     return {
-      props: {
-        fetchedUser: fetchedUser
-      },
-      context: {
-        fetchedUser: fetchedUser
-      }
+      props: { fetchedUser },
+      context: { fetchedUser },
     };
   }
 </script>
@@ -39,7 +31,7 @@
   import Navbar from "$lib/Navbar.svelte";
 
   export let fetchedUser;
-  if (browser && fetchedUser) {
+  if (browser) {
     user.set(fetchedUser);
   }
 </script>

--- a/src/routes/__layout.svelte
+++ b/src/routes/__layout.svelte
@@ -4,8 +4,6 @@
   import { user } from "$lib/store";
 
   export async function load({ fetch, session }) {
-    console.log("load", session);
-
     if (!session.jwt) {
       return {
         props: {

--- a/src/routes/__layout.svelte
+++ b/src/routes/__layout.svelte
@@ -22,24 +22,16 @@
     }
 
     const res = await fetch("/user.json");
+    const fetchedUser = await res.text();
 
-    if (browser) {
-      return {
-        props: {
-          fetchedUser: await res.text()
-        }
-      };
-    } else {
-      const fetchedUser = await res.text();
-      return {
-        props: {
-          fetchedUser: fetchedUser
-        },
-        context: {
-          fetchedUser: fetchedUser
-        }
-      };
-    }
+    return {
+      props: {
+        fetchedUser: fetchedUser
+      },
+      context: {
+        fetchedUser: fetchedUser
+      }
+    };
   }
 </script>
 

--- a/src/routes/__layout.svelte
+++ b/src/routes/__layout.svelte
@@ -1,4 +1,5 @@
 <script context="module">
+  import { browser } from "$app/env";
   import { get } from "svelte/store";
   import { user } from "$lib/store";
 
@@ -14,7 +15,7 @@
     }
 
     const storedUser = get(user);
-    if (storedUser) {
+    if (browser && storedUser) {
       return {
         props: {
           fetchedUser: storedUser
@@ -24,11 +25,23 @@
 
     const res = await fetch("/user.json");
 
-    return {
-      props: {
-        fetchedUser: await res.text()
-      }
-    };
+    if (browser) {
+      return {
+        props: {
+          fetchedUser: await res.text()
+        }
+      };
+    } else {
+      const fetchedUser = await res.text();
+      return {
+        props: {
+          fetchedUser: fetchedUser
+        },
+        context: {
+          fetchedUser: fetchedUser
+        }
+      };
+    }
   }
 </script>
 
@@ -36,10 +49,10 @@
   import Navbar from "$lib/Navbar.svelte";
 
   export let fetchedUser;
-  if (fetchedUser) {
+  if (browser && fetchedUser) {
     user.set(fetchedUser);
   }
 </script>
 
-<Navbar />
+<Navbar user={fetchedUser} />
 <slot />

--- a/src/routes/index.svelte
+++ b/src/routes/index.svelte
@@ -1,7 +1,25 @@
+<script context="module">
+  export async function load({ context }) {
+    if (context.fetchedUser) {
+      return {
+        props: {
+          fetchedUser: context.fetchedUser
+        }
+      };
+    }
+
+    return {};
+  }
+</script>
+
 <script>
-  import { content, user } from "$lib/store";
+  import { tick } from "svelte";
+  import { user as userStore } from "$lib/store";
   import { session } from "$app/stores";
   import { goto } from "$app/navigation";
+
+  export let fetchedUser;
+  $: user = $userStore || fetchedUser;
 
   function setCookie(name, value) {
     document.cookie = name + "=" + value + "; max-age=31536000; path=/";
@@ -10,13 +28,13 @@
   function login() {
     setCookie("jwt", "abc");
     $session.jwt = "abc";
-    goto("/protected");
+    tick().then(() => goto("/protected"));
   }
 </script>
 
 <h1>Welcome to SvelteKit</h1>
 
-{#if $user}
+{#if user}
   <p>
     <a href="/protected">protected</a>
   </p>

--- a/src/routes/index.svelte
+++ b/src/routes/index.svelte
@@ -13,7 +13,6 @@
 </script>
 
 <script>
-  import { tick } from "svelte";
   import { user as userStore } from "$lib/store";
   import { session } from "$app/stores";
   import { goto } from "$app/navigation";
@@ -28,7 +27,7 @@
   function login() {
     setCookie("jwt", "abc");
     $session.jwt = "abc";
-    tick().then(() => goto("/protected"));
+    goto("/protected");
   }
 </script>
 

--- a/src/routes/index.svelte
+++ b/src/routes/index.svelte
@@ -1,14 +1,10 @@
 <script context="module">
   export async function load({ context }) {
-    if (context) {
-      return {
-        props: {
-          fetchedUser: context.fetchedUser
-        }
-      };
-    }
-
-    return {};
+    return {
+      props: {
+        fetchedUser: context.fetchedUser
+      }
+    };
   }
 </script>
 

--- a/src/routes/index.svelte
+++ b/src/routes/index.svelte
@@ -1,6 +1,6 @@
 <script context="module">
   export async function load({ context }) {
-    if (context.fetchedUser) {
+    if (context) {
       return {
         props: {
           fetchedUser: context.fetchedUser

--- a/src/routes/protected/__layout.svelte
+++ b/src/routes/protected/__layout.svelte
@@ -5,6 +5,7 @@
   import Navbar from "$lib/Navbar.svelte";
 
   export async function load({ fetch, session }) {
+    // Redirect if not logged in
     if (!session.jwt) {
       return {
         status: 302,
@@ -12,26 +13,21 @@
       };
     }
 
+    // If we already have the content, then don't fetch it again
     const storedContent = get(content);
-
     if (browser && storedContent) {
       return {
-        props: {
-          fetchedContent: storedContent
-        }
+        props: { fetchedContent: storedContent },
       };
     }
 
+    // Fetch remote content, give it back as a prop AND context
     const res = await fetch("/protected.json");
     const fetchedContent = await res.text();
 
     return {
-      props: {
-        fetchedContent: fetchedContent
-      },
-      context: {
-        fetchedContent: fetchedContent
-      }
+      props: { fetchedContent },
+      context: { fetchedContent },
     };
   }
 </script>
@@ -39,7 +35,8 @@
 <script>
   export let fetchedContent;
 
-  if (browser && fetchedContent) {
+  // If we're running in the browser, then we can save the fetched content in the store
+  if (browser) {
     $content = fetchedContent;
   }
 </script>

--- a/src/routes/protected/__layout.svelte
+++ b/src/routes/protected/__layout.svelte
@@ -23,20 +23,16 @@
     }
 
     const res = await fetch("/protected.json");
+    const fetchedContent = await res.text();
 
-    if (browser) {
-      return {
-        props: {
-          fetchedContent: await res.text()
-        }
-      };
-    } else {
-      return {
-        context: {
-          fetchedContent: await res.text()
-        }
-      };
-    }
+    return {
+      props: {
+        fetchedContent: fetchedContent
+      },
+      context: {
+        fetchedContent: fetchedContent
+      }
+    };
   }
 </script>
 

--- a/src/routes/protected/__layout.svelte
+++ b/src/routes/protected/__layout.svelte
@@ -17,7 +17,7 @@
     const storedContent = get(content);
     if (browser && storedContent) {
       return {
-        props: { fetchedContent: storedContent },
+        props: { fetchedContent: storedContent }
       };
     }
 
@@ -27,7 +27,7 @@
 
     return {
       props: { fetchedContent },
-      context: { fetchedContent },
+      context: { fetchedContent }
     };
   }
 </script>

--- a/src/routes/protected/__layout.svelte
+++ b/src/routes/protected/__layout.svelte
@@ -1,4 +1,5 @@
 <script context="module">
+  import { browser } from "$app/env";
   import { get } from "svelte/store";
   import { content } from "$lib/store";
   import Navbar from "$lib/Navbar.svelte";
@@ -13,7 +14,7 @@
 
     const storedContent = get(content);
 
-    if (storedContent) {
+    if (browser && storedContent) {
       return {
         props: {
           fetchedContent: storedContent
@@ -23,18 +24,26 @@
 
     const res = await fetch("/protected.json");
 
-    return {
-      props: {
-        fetchedContent: await res.text()
-      }
-    };
+    if (browser) {
+      return {
+        props: {
+          fetchedContent: await res.text()
+        }
+      };
+    } else {
+      return {
+        context: {
+          fetchedContent: await res.text()
+        }
+      };
+    }
   }
 </script>
 
 <script>
   export let fetchedContent;
 
-  if (fetchedContent) {
+  if (browser && fetchedContent) {
     $content = fetchedContent;
   }
 </script>

--- a/src/routes/protected/index.svelte
+++ b/src/routes/protected/index.svelte
@@ -23,5 +23,6 @@
 <p>{content}</p>
 
 <p>
+  <a href="/">home</a>
   <a href="/protected/subpage">subpage</a>
 </p>

--- a/src/routes/protected/index.svelte
+++ b/src/routes/protected/index.svelte
@@ -1,9 +1,25 @@
+<script context="module">
+  export async function load({ context }) {
+    if (context.fetchedContent) {
+      return {
+        props: {
+          fetchedContent: context.fetchedContent
+        }
+      };
+    }
+
+    return {};
+  }
+</script>
+
 <script>
-  import { content } from "$lib/store";
+  import { content as contentStore } from "$lib/store";
+  export let fetchedContent;
+  $: content = $contentStore || fetchedContent;
 </script>
 
 <p>Reload your browser and you'll see the old content briefly appear.</p>
-<p>{$content}</p>
+<p>{content}</p>
 
 <p>
   <a href="/protected/subpage">subpage</a>

--- a/src/routes/protected/index.svelte
+++ b/src/routes/protected/index.svelte
@@ -1,11 +1,7 @@
 <script context="module">
+  // Forward all context to the props
   export async function load({ context }) {
-    return {
-      props: {
-        fetchedContent: context.fetchedContent,
-        fetchedUser: context.fetchedUser
-      }
-    };
+    return { props: context };
   }
 </script>
 
@@ -13,6 +9,9 @@
   import { user as userStore, content as contentStore } from "$lib/store";
   export let fetchedContent;
   export let fetchedUser;
+
+  // The magic sauce: use the content in the store, but fallback to the context,
+  // which is needed for SSR.
   $: content = $contentStore || fetchedContent;
   $: user = $userStore || fetchedUser;
 </script>

--- a/src/routes/protected/index.svelte
+++ b/src/routes/protected/index.svelte
@@ -1,9 +1,10 @@
 <script context="module">
   export async function load({ context }) {
-    if (context.fetchedContent) {
+    if (context) {
       return {
         props: {
-          fetchedContent: context.fetchedContent
+          fetchedContent: context.fetchedContent,
+          fetchedUser: context.fetchedUser
         }
       };
     }
@@ -13,12 +14,17 @@
 </script>
 
 <script>
-  import { content as contentStore } from "$lib/store";
+  import { user as userStore, content as contentStore } from "$lib/store";
   export let fetchedContent;
+  export let fetchedUser;
   $: content = $contentStore || fetchedContent;
+  $: user = $userStore || fetchedUser;
 </script>
 
-<p>Reload your browser and you'll see the old content briefly appear.</p>
+<p>
+  Hello {user}! Reload your browser and you'll see the old content briefly
+  appear.
+</p>
 <p>{content}</p>
 
 <p>

--- a/src/routes/protected/index.svelte
+++ b/src/routes/protected/index.svelte
@@ -1,15 +1,11 @@
 <script context="module">
   export async function load({ context }) {
-    if (context) {
-      return {
-        props: {
-          fetchedContent: context.fetchedContent,
-          fetchedUser: context.fetchedUser
-        }
-      };
-    }
-
-    return {};
+    return {
+      props: {
+        fetchedContent: context.fetchedContent,
+        fetchedUser: context.fetchedUser
+      }
+    };
   }
 </script>
 

--- a/src/routes/protected/subpage.svelte
+++ b/src/routes/protected/subpage.svelte
@@ -1,11 +1,6 @@
 <script context="module">
   export async function load({ context }) {
-    return {
-      props: {
-        fetchedContent: context.fetchedContent,
-        fetchedUser: context.fetchedUser
-      }
-    };
+    return { props: context };
   }
 </script>
 

--- a/src/routes/protected/subpage.svelte
+++ b/src/routes/protected/subpage.svelte
@@ -1,12 +1,31 @@
+<script context="module">
+  export async function load({ context }) {
+    if (context) {
+      return {
+        props: {
+          fetchedContent: context.fetchedContent,
+          fetchedUser: context.fetchedUser
+        }
+      };
+    }
+
+    return {};
+  }
+</script>
+
 <script>
-  import { content } from "$lib/store";
+  import { user as userStore, content as contentStore } from "$lib/store";
+  export let fetchedContent;
+  export let fetchedUser;
+  $: content = $contentStore || fetchedContent;
+  $: user = $userStore || fetchedUser;
 </script>
 
 <p>
-  This should show the same content
+  Hi {user}, this should show the same content
   <b>without doing another request to the REST server.</b>
 </p>
-<p>{$content}</p>
+<p>{content}</p>
 
 <p>
   <a href="/protected">back</a>

--- a/src/routes/protected/subpage.svelte
+++ b/src/routes/protected/subpage.svelte
@@ -1,15 +1,11 @@
 <script context="module">
   export async function load({ context }) {
-    if (context) {
-      return {
-        props: {
-          fetchedContent: context.fetchedContent,
-          fetchedUser: context.fetchedUser
-        }
-      };
-    }
-
-    return {};
+    return {
+      props: {
+        fetchedContent: context.fetchedContent,
+        fetchedUser: context.fetchedUser
+      }
+    };
   }
 </script>
 


### PR DESCRIPTION
The main key takeaway from the problems I was seeing with the content (on refresh it flashes from old content to new content, and the old content is shared between browsers), is that using Svelte stores from SSR is a hard no. That state is shared across all clients, so it's just not usable.

The initial fix to simply add a check to see if we're in the browser wasn't ideal, as you'd now see content flash from "undefined" to the actual content (see also [this article](https://www.loopwerk.io/articles/2021/architecting-sveltekit/)). By adding contexts and using either the store or the context as a fallback, I've solved all the content problems, but at the cost of considerable boilerplate.

The problem where after login the header wasn't updated also fixed itself.