### PR TITLE
Prevent content flashes by simply not caching anything

### DIFF
--- a/src/routes/__layout.svelte
+++ b/src/routes/__layout.svelte
@@ -19,11 +19,13 @@
 </script>
 
 <script>
+  import { tick } from "svelte";
   import { user } from "$lib/store";
   import Navbar from "$lib/Navbar.svelte";
 
   export let fetchedUser;
   user.set(fetchedUser);
+  tick();
 </script>
 
 <Navbar />

--- a/src/routes/__layout.svelte
+++ b/src/routes/__layout.svelte
@@ -1,23 +1,9 @@
 <script context="module">
-  import { get } from "svelte/store";
-  import { user } from "$lib/store";
-
   export async function load({ fetch, session }) {
-    console.log("load", session);
-
     if (!session.jwt) {
       return {
         props: {
           fetchedUser: false
-        }
-      };
-    }
-
-    const storedUser = get(user);
-    if (storedUser) {
-      return {
-        props: {
-          fetchedUser: storedUser
         }
       };
     }
@@ -33,12 +19,11 @@
 </script>
 
 <script>
+  import { user } from "$lib/store";
   import Navbar from "$lib/Navbar.svelte";
 
   export let fetchedUser;
-  if (fetchedUser) {
-    user.set(fetchedUser);
-  }
+  user.set(fetchedUser);
 </script>
 
 <Navbar />

--- a/src/routes/protected/__layout.svelte
+++ b/src/routes/protected/__layout.svelte
@@ -1,23 +1,9 @@
 <script context="module">
-  import { get } from "svelte/store";
-  import { content } from "$lib/store";
-  import Navbar from "$lib/Navbar.svelte";
-
   export async function load({ fetch, session }) {
     if (!session.jwt) {
       return {
         status: 302,
         redirect: "/"
-      };
-    }
-
-    const storedContent = get(content);
-
-    if (storedContent) {
-      return {
-        props: {
-          fetchedContent: storedContent
-        }
       };
     }
 
@@ -32,11 +18,11 @@
 </script>
 
 <script>
-  export let fetchedContent;
+  import { content } from "$lib/store";
+  import Navbar from "$lib/Navbar.svelte";
 
-  if (fetchedContent) {
-    $content = fetchedContent;
-  }
+  export let fetchedContent;
+  $content = fetchedContent;
 </script>
 
 <slot />

--- a/src/routes/protected/index.svelte
+++ b/src/routes/protected/index.svelte
@@ -6,5 +6,6 @@
 <p>{$content}</p>
 
 <p>
+  <a href="/">home</a>
   <a href="/protected/subpage">subpage</a>
 </p>


### PR DESCRIPTION
While it does solve the problem that you briefly see old content, it is now doing too many requests: when you switch from home to the protected page, back to home and protected again, it makes a request to the `index.json` endpoint every time - which is exactly what I am trying to prevent from happening.